### PR TITLE
platform.ini configured for multiple environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,14 @@ install:
   - pip install -U platformio
   - platformio update
 
-script:
-  - platformio run
+  jobs:
+    include:
+      - stage: test
+        name: "CI test"
+        script: platformio test
+      
+      - stage: build
+        name: "CI build"
+        script: platformio run
+        
+

--- a/README.md
+++ b/README.md
@@ -16,19 +16,24 @@ brew install platformio
 
 ## Development
 
-After creating a feature branch, you can build locally without the module plugged in to make sure the code can compile
+After creating a feature branch and making your changes, you can build locally without the board plugged in to make sure the code can compile. There are two building environments specified in `platform.ini`:
+
+- `[env:uno]` is the default environment, for building, uploading, and CI testing
+- `[env:native]` is for onboard unit testing
+
+To perform CI testing and building without the board plugged in you can simply run
 
 ```
-pio run
+pio test && pio run
 ```
 
-Then plug the prototype board into your computer to unit test
+Then plug the prototype board into your computer to perform unit tests
 
 ```
-pio test
+pio test -e native
 ```
 
-Finally, upload the code with the optional `monitor` flag to view the output of any Serial monitors put in for debugging.
+Finally, upload the code with the optional `monitor` flag to view the output of any Serial printing put in the code for debugging.
 
 ```
 pio run --target upload --target monitor

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,12 +8,22 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+;==================================================;
+
+; Default build environment for ATMEGA328 
+[platformio]
+default_envs = uno
+
+; For building, uploading, CI testing
 [env:uno]
 platform = atmelavr
 board = uno
 framework = arduino
 test_ignore = test_desktop
 
+; For onboard unit testing 
+; Run 'pio test -e native' with board plugged in
 [env:native]
 platform = native
 test_ignore = test_embedded
+build_type = debug


### PR DESCRIPTION
On-board unit testing and off-board CI testing should be exclusive now

Additionally, there's a default environment declared in `platform.ini` so that we don't get error messages on builds